### PR TITLE
Update documentation.md

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -415,7 +415,7 @@ All custom fields are placed in the Secondary tabs container (next to Content fi
 
 Alternatively you may use the field type as the tag name, here we use the `{text}` tag to directly render the `tagline` variable:
 
-    <h1>{text name="tagline" label="Tagline"}Our wonderful website{/text}</h1>
+    <h1>{text name="tagline" label="Tagline"}{/text}</h1>
 
 You may also use the `{repeater}` tag for repeating content:
 


### PR DESCRIPTION
The 'default' text does not work and would be weird to support. Searching in code wouldn't make sense because the client changed the text anyways? Also if client leaves this field empty, you will render empty HTML elements. Which makes me even think this entire feature should be removed?

BennoThommo:

> I've noticed the same issue before. Currently, it won't use a default value like that, and I think the reasoning is because when you save the field in the Backend without entering anything in the field, it saves the field as an empty value. The problem is, there's no way to tell if it's intentionally empty or not - for example, if you're offering this theme to a client to modify, they may intentionally not want a tagline to be used on a page, so they would leave the field blank.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->