### PR TITLE
Fix issue with Primary Tabs losing min-size class

### DIFF
--- a/assets/js/pages-page.js
+++ b/assets/js/pages-page.js
@@ -464,7 +464,7 @@
             $panel.append($collapseIcon)
 
             if (!hasSecondaryTabs) {
-                $('.primary-tabs').parent().removeClass('min-size')
+                $(data.pane).find('.primary-tabs').parent().removeClass('min-size')
             }
 
             $collapseIcon.click(function(){


### PR DESCRIPTION
When opening a new tab in the editor, if it does not have secondary tabs then it will remove `min-size` from the primary tabs so that they occupy the whole height.

However, the selector is so loose that it affects all primary tabs that exist, which means other tabs will be impacted when they shouldn't.

This PR narrows down the selector looking for primary tabs to only inside the page at hand

@LukeTowers