### PR TITLE
Fix issue with subpages of home would get 2 slashes

### DIFF
--- a/controllers/index/_form_page.htm
+++ b/controllers/index/_form_page.htm
@@ -17,7 +17,10 @@
     <?php endif ?>
 
     <?php if (isset($parentPage)): ?>
-        <input type="hidden" data-parent-url value="<?= e($parentPage->getViewBag()->property('url')) ?>" />
+        <input type="hidden" data-parent-url
+               value="<?= e($parentPage->getViewBag()->property('url')) === '/'
+                        ? ''
+                        : e($parentPage->getViewBag()->property('url')) ?>"/>
     <?php endif ?>
 
     <input type="hidden" value="0" name="objectForceSave" />


### PR DESCRIPTION
When creating a subpage for the Homepage (with `/` url), the preset would automatically prepend an extra `/` at the start of the url. This was the expected behaviour but doesn't make sense just on the `/` page.

This PR resolves the issue by passing the parent url appropriately.

