### PR TITLE
Fix issue where allowed ips

### DIFF
--- a/components/StaticPage.php
+++ b/components/StaticPage.php
@@ -157,7 +157,8 @@ class StaticPage extends ComponentBase
     {
         return MaintenanceSetting::isConfigured() &&
             MaintenanceSetting::get('is_enabled', false) &&
-            !\BackendAuth::getUser();
+            !MaintenanceSetting::isAllowedIp(Request::ip()) &&
+            !BackendAuth::getUser();
     }
 
     /**


### PR DESCRIPTION
If you whitelist and IP, it can access the website but can't see the static pages content. This fix resolves that and uses the same checks as `modules/cms/classes/Controller.php:154`