### PR TITLE
Fix Static Page translations

### DIFF
--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -149,7 +149,7 @@ class ObjectHelper
                 $object->parentFileName = $data['parentFileName'] ?? null;
 
                 $placeholders = array_get($data, 'placeholders');
-                if (is_array($placeholders)) {
+                if (is_array($placeholders) && Config::get('cms.convertLineEndings', false) === true) {
                     $placeholders = array_map([static::class, 'convertLineEndings'], $placeholders);
                 }
 
@@ -185,7 +185,7 @@ class ObjectHelper
                 break;
         }
 
-        if (!empty($objectData['markup'])) {
+        if (!empty($objectData['markup']) && Config::get('cms.convertLineEndings', false) === true) {
             $objectData['markup'] = static::convertLineEndings($objectData['markup']);
         }
 

--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -6,6 +6,7 @@ use Cms\Classes\CmsObject;
 use Cms\Classes\Theme;
 use Config;
 use Lang;
+use Request;
 use Session;
 
 class ObjectHelper
@@ -107,7 +108,7 @@ class ObjectHelper
     /**
      * Fills the provided Winter.Pages object with the provided data
      */
-    public static function fillObject(Theme $theme, string $type, string $path, array $data): CmsObject
+    public static function fillObject(Theme $theme, string $type, string $path, array $data, $controller = null): CmsObject
     {
         $objectData = [];
 
@@ -120,6 +121,12 @@ class ObjectHelper
         // Set page layout super early because it cascades to other elements
         if ($type === 'page' && ($layout = $data['viewBag']['layout'] ?? null)) {
             $object->getViewBag()->setProperty('layout', $layout);
+        }
+
+        if ($controller) {
+            $formWidget = $controller->makeObjectFormWidget($type, $object, Request::input('formWidgetAlias'));
+            $saveData = $formWidget->getSaveData();
+            $data = array_merge($data, $saveData);
         }
 
         // Store viewBag data in the object's "settings" property

--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -149,7 +149,7 @@ class ObjectHelper
                 $object->parentFileName = $data['parentFileName'] ?? null;
 
                 $placeholders = array_get($data, 'placeholders');
-                if (is_array($placeholders) && Config::get('cms.convertLineEndings', false) === true) {
+                if (is_array($placeholders)) {
                     $placeholders = array_map([static::class, 'convertLineEndings'], $placeholders);
                 }
 
@@ -185,7 +185,7 @@ class ObjectHelper
                 break;
         }
 
-        if (!empty($objectData['markup']) && Config::get('cms.convertLineEndings', false) === true) {
+        if (!empty($objectData['markup'])) {
             $objectData['markup'] = static::convertLineEndings($objectData['markup']);
         }
 

--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -1,7 +1,6 @@
 <?php namespace Winter\Pages\Classes;
 
 use ApplicationException;
-use Backend\Classes\Controller;
 use Cms\Classes\CmsCompoundObject;
 use Cms\Classes\CmsObject;
 use Cms\Classes\Theme;
@@ -109,25 +108,21 @@ class ObjectHelper
     /**
      * Fills the provided Winter.Pages object with the provided data
      */
-    public static function fillObject(Theme $theme, string $type, string $path, array $data, ?Controller $controller = null): CmsObject
+    public static function fillObject(Theme $theme, string $type, string $path, array $data, ?CmsObject $object = null): CmsObject
     {
         $objectData = [];
 
         // Get the object to fill
-        $path = trim($path);
-        $object = !empty($path)
-            ? static::loadObject($theme, $type, $path)
-            : static::createObject($theme, $type);
+        if (is_null($object)) {
+            $path = trim($path);
+            $object = !empty($path)
+                ? static::loadObject($theme, $type, $path)
+                : static::createObject($theme, $type);
+        }
 
         // Set page layout super early because it cascades to other elements
         if ($type === 'page' && ($layout = $data['viewBag']['layout'] ?? null)) {
             $object->getViewBag()->setProperty('layout', $layout);
-        }
-
-        if ($controller) {
-            $formWidget = $controller->makeObjectFormWidget($type, $object, Request::input('formWidgetAlias'));
-            $saveData = $formWidget->getSaveData();
-            $data = array_merge($data, $saveData);
         }
 
         // Store viewBag data in the object's "settings" property

--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Pages\Classes;
 
 use ApplicationException;
+use Backend\Classes\Controller;
 use Cms\Classes\CmsCompoundObject;
 use Cms\Classes\CmsObject;
 use Cms\Classes\Theme;
@@ -108,7 +109,7 @@ class ObjectHelper
     /**
      * Fills the provided Winter.Pages object with the provided data
      */
-    public static function fillObject(Theme $theme, string $type, string $path, array $data, $controller = null): CmsObject
+    public static function fillObject(Theme $theme, string $type, string $path, array $data, ?Controller $controller = null): CmsObject
     {
         $objectData = [];
 

--- a/classes/ObjectHelper.php
+++ b/classes/ObjectHelper.php
@@ -6,7 +6,6 @@ use Cms\Classes\CmsObject;
 use Cms\Classes\Theme;
 use Config;
 use Lang;
-use Request;
 use Session;
 
 class ObjectHelper

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -127,8 +127,7 @@ class Index extends Controller
             $this->theme,
             $type,
             Request::input('objectPath'),
-            post(),
-            $this
+            post()
         );
     }
 

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -127,7 +127,8 @@ class Index extends Controller
             $this->theme,
             $type,
             Request::input('objectPath'),
-            post()
+            post(),
+            $this
         );
     }
 
@@ -202,14 +203,8 @@ class Index extends Controller
     public function onSave()
     {
         $this->validateRequestTheme();
-        $type = $this->getObjectType();
 
-        $object = ObjectHelper::fillObject(
-            $this->theme,
-            $type,
-            Request::input('objectPath'),
-            post()
-        );
+        $object = $this->getObjectFromRequest();
         $object->save();
 
         /*
@@ -353,13 +348,7 @@ class Index extends Controller
     {
         $this->validateRequestTheme();
 
-        $type = $this->getObjectType();
-        $object = ObjectHelper::fillObject(
-            $this->theme,
-            $type,
-            Request::input('objectPath'),
-            post()
-        );
+        $object = $this->getObjectFromRequest();
 
         return $this->pushObjectForm($type, $object, Request::input('formWidgetAlias'));
     }
@@ -564,7 +553,7 @@ class Index extends Controller
         }
     }
 
-    protected function makeObjectFormWidget($type, $object, $alias = null)
+    public function makeObjectFormWidget($type, $object, $alias = null)
     {
         $formConfigs = [
             'page'    => '~/plugins/winter/pages/classes/page/fields.yaml',

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -214,13 +214,7 @@ class Index extends Controller
         $saveData = $formWidget->getSaveData();
         $data = array_merge($data, $saveData);
 
-        ObjectHelper::fillObject(
-            $theme,
-            $type,
-            $path,
-            $data,
-            $object
-        );
+        ObjectHelper::fillObject($theme, $type, $path, $data, $object);
 
         $object->save();
 

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -203,14 +203,25 @@ class Index extends Controller
     {
         $this->validateRequestTheme();
 
+        $data = post();
+        $path = trim(Request::input('objectPath'));
+        $theme = $this->theme;
         $type = $this->getObjectType();
-        $object = ObjectHelper::fillObject(
-            $this->theme,
+
+        $object = !empty($path) ? ObjectHelper::loadObject($theme, $type, $path) : ObjectHelper::createObject($theme, $type);
+
+        $formWidget = $this->makeObjectFormWidget($type, $object, Request::input('formWidgetAlias'));
+        $saveData = $formWidget->getSaveData();
+        $data = array_merge($data, $saveData);
+
+        ObjectHelper::fillObject(
+            $theme,
             $type,
-            Request::input('objectPath'),
-            post(),
-            $this
+            $path,
+            $data,
+            $object
         );
+
         $object->save();
 
         /*
@@ -359,8 +370,7 @@ class Index extends Controller
             $this->theme,
             $type,
             Request::input('objectPath'),
-            post(),
-            $this
+            post()
         );
 
         return $this->pushObjectForm($type, $object, Request::input('formWidgetAlias'));
@@ -566,7 +576,7 @@ class Index extends Controller
         }
     }
 
-    public function makeObjectFormWidget($type, $object, $alias = null)
+    protected function makeObjectFormWidget($type, $object, $alias = null)
     {
         $formConfigs = [
             'page'    => '~/plugins/winter/pages/classes/page/fields.yaml',

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -204,7 +204,14 @@ class Index extends Controller
     {
         $this->validateRequestTheme();
 
-        $object = $this->getObjectFromRequest();
+        $type = $this->getObjectType();
+        $object = ObjectHelper::fillObject(
+            $this->theme,
+            $type,
+            Request::input('objectPath'),
+            post(),
+            $this
+        );
         $object->save();
 
         /*
@@ -348,7 +355,14 @@ class Index extends Controller
     {
         $this->validateRequestTheme();
 
-        $object = $this->getObjectFromRequest();
+        $type = $this->getObjectType();
+        $object = ObjectHelper::fillObject(
+            $this->theme,
+            $type,
+            Request::input('objectPath'),
+            post(),
+            $this
+        );
 
         return $this->pushObjectForm($type, $object, Request::input('formWidgetAlias'));
     }


### PR DESCRIPTION
Fixes #26 

- Tested by creating a page with title/url in two languages
- Tested by adding this Static Page to the Sitemap plugin (entries were properly created for both languages)