### PR TITLE
Fix deprecation notice when attempting to resolve a non-static page

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -285,7 +285,7 @@ class Plugin extends PluginBase
              * Get rendered content
              */
             $contents = Controller::instance()->getPageContents($page);
-            if (strlen($contents)) {
+            if (($contents != null) and strlen($contents)) {
                 return $contents;
             }
         });

--- a/Plugin.php
+++ b/Plugin.php
@@ -285,7 +285,7 @@ class Plugin extends PluginBase
              * Get rendered content
              */
             $contents = Controller::instance()->getPageContents($page);
-            if (($contents != null) and strlen($contents)) {
+            if (!empty($contents)) {
                 return $contents;
             }
         });


### PR DESCRIPTION
Fixing 
`ErrorException: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/plugins/winter/pages/Plugin.php:288`

