### PR TITLE
Bind form widget to controller when duplicating a page

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -311,6 +311,8 @@ class Index extends Controller
         $duplicatedObject = new $className($data);
 
         $widget = $this->makeObjectFormWidget($type, $duplicatedObject);
+        $widget->bindToController();
+
         $this->vars['objectPath'] = '';
         $this->vars['canCommit'] = $this->canCommitObject($duplicatedObject);
         $this->vars['canReset'] = $this->canResetObject($duplicatedObject);


### PR DESCRIPTION
This fixes the modified page counter not working when updating a duplicated page, because the hidden inputs were not in the expected location.

This fixed the second part of my comment: https://github.com/wintercms/wn-pages-plugin/issues/42#issuecomment-2171763701